### PR TITLE
added pytest_fixture_setup

### DIFF
--- a/pytest_lazyfixture.py
+++ b/pytest_lazyfixture.py
@@ -12,6 +12,16 @@ PY3 = sys.version_info[0] == 3
 string_type = str if PY3 else basestring
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_fixture_setup(fixturedef, request):
+    outcome = yield
+    result = outcome.get_result()
+    if is_lazy_fixture(result):
+        result = request.getfixturevalue(result.name)
+        fixturedef.cached_result = (result, request.param_index, None)
+    return result
+
+
 def pytest_namespace():
     return {'lazy_fixture': lazy_fixture}
 
@@ -41,13 +51,6 @@ def fillfixtures(_fillfixtures):
 
         _fillfixtures()
     return fill
-
-
-def pytest_runtest_call(item):
-    if hasattr(item, 'funcargs'):
-        for arg, val in item.funcargs.items():
-            if is_lazy_fixture(val):
-                item.funcargs[arg] = item._request.getfixturevalue(val.name)
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-lazy-fixture',
-    version='0.3.0',
+    version='0.3.1',
     author='Marsel Zaripov',
     author_email='marszaripov@gmail.com',
     maintainer='Marsel Zaripov',


### PR DESCRIPTION
Hi, thanks for awsome plugin. I recently run in unpleasant problem in my package (pytest_matrix), where I generate multiple tests by fixture combinations using your pytest-lazy-fixture plugin. Everything works fine, but if you use some fixture (let say fixture A) as indirect fixture and in this indirect fixture A you use want to access another indirect fixture B you recieve LazyFixture instead actual value.
I fixed it in my project by using pytest_fixture_setup hook. So if you find it usefull, it would be grate.
Thanks and best regards
DB