### PR TITLE
indirect fixtures

### DIFF
--- a/pytest_lazyfixture.py
+++ b/pytest_lazyfixture.py
@@ -12,14 +12,14 @@ PY3 = sys.version_info[0] == 3
 string_type = str if PY3 else basestring
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_fixture_setup(fixturedef, request):
-    outcome = yield
-    result = outcome.get_result()
-    if is_lazy_fixture(result):
-        result = request.getfixturevalue(result.name)
-        fixturedef.cached_result = (result, request.param_index, None)
-    return result
+# @pytest.hookimpl(hookwrapper=True)
+# def pytest_fixture_setup(fixturedef, request):
+#     outcome = yield
+#     result = outcome.get_result()
+#     if is_lazy_fixture(result):
+#         result = request.getfixturevalue(result.name)
+#         fixturedef.cached_result = (result, request.param_index, None)
+#     return result
 
 
 def pytest_namespace():
@@ -67,6 +67,13 @@ def normalize_metafunc_calls(metafunc, valtype):
         calls = normalize_call(callspec, metafunc, valtype)
         newcalls.extend(calls)
     metafunc._calls = newcalls
+
+
+def pytest_runtest_call(item):
+    if hasattr(item, 'funcargs'):
+        for arg, val in item.funcargs.items():
+            if is_lazy_fixture(val):
+                item.funcargs[arg] = item._request.getfixturevalue(val.name)
 
 
 def normalize_call(callspec, metafunc, valtype, used_keys=None):

--- a/pytest_lazyfixture.py
+++ b/pytest_lazyfixture.py
@@ -12,6 +12,16 @@ PY3 = sys.version_info[0] == 3
 string_type = str if PY3 else basestring
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_fixture_setup(fixturedef, request):
+    outcome = yield
+    result = outcome.get_result()
+    if is_lazy_fixture(result):
+        result = request.getfixturevalue(result.name)
+        fixturedef.cached_result = (result, request.param_index, None)
+    return result
+
+
 def pytest_namespace():
     return {'lazy_fixture': lazy_fixture}
 
@@ -41,13 +51,6 @@ def fillfixtures(_fillfixtures):
 
         _fillfixtures()
     return fill
-
-
-def pytest_runtest_call(item):
-    if hasattr(item, 'funcargs'):
-        for arg, val in item.funcargs.items():
-            if is_lazy_fixture(val):
-                item.funcargs[arg] = item._request.getfixturevalue(val.name)
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-lazy-fixture',
-    version='0.3.0',
+    version='0.3.1',
     author='Marsel Zaripov',
     author_email='marszaripov@gmail.com',
     maintainer='Marsel Zaripov',


### PR DESCRIPTION
Hi, you asked me about some example for the issue I tried to resolve by the pull request from yestrday. So I added test to test_lazyfixture.py. It is basicly about indirect lazy_fixtures in test generator, which can do some modificition (in examle it is list modificition, but in real life it is usualy some db modificition etc...). If you run tests, the new test will fail on TypeError: 'LazyFixture' object does not support indexing. Beacause LazyFixture is never inicialized. If you uncommented lines 15-24 in pytest_lazyfixture.py, the test will pass.