### PR TITLE
Enable lazy fixtures with parametrized subfixtures and lazy fixtures in subfixtures

### DIFF
--- a/pytest_lazyfixture.py
+++ b/pytest_lazyfixture.py
@@ -41,6 +41,13 @@ def fillfixtures(_fillfixtures):
     return fill
 
 
+@pytest.hookimpl(tryfirst=True)
+def pytest_fixture_setup(fixturedef, request):
+    val = getattr(request, 'param', None)
+    if is_lazy_fixture(val):
+        request.param = request.getfixturevalue(val.name)
+
+
 def pytest_runtest_call(item):
     if hasattr(item, 'funcargs'):
         for arg, val in item.funcargs.items():

--- a/tests/test_lazyfixture.py
+++ b/tests/test_lazyfixture.py
@@ -373,7 +373,7 @@ def test_issues10_xfail(testdir):
             return request.param
 
         @pytest.mark.parametrize(('a', 'b'), [
-            pytest.mark.xfail((1, pytest.lazy_fixture('zero')), reason=ZeroDivisionError)
+            pytest.param(1, pytest.lazy_fixture('zero'), marks=pytest.mark.xfail(reason=ZeroDivisionError))
         ])
         def test_division(a, b):
             division(a, b)
@@ -411,7 +411,7 @@ def test_issues12_skip_test_function(testdir):
             return 1
 
         @pytest.mark.parametrize('a', [
-            pytest.mark.skip(pytest.lazy_fixture('one'), reason='skip')
+            pytest.param(pytest.lazy_fixture('one'), marks=pytest.mark.skip(reason='skip'))
         ])
         def test_skip1(a):
             assert a == 1
@@ -447,7 +447,7 @@ def test_issues12_skip_test_method(testdir):
                 assert a == 1
 
             @pytest.mark.parametrize('a', [
-                pytest.mark.skip(pytest.lazy_fixture('one'), reason='skip this')
+                pytest.param(pytest.lazy_fixture('one'), marks=pytest.mark.skip(reason='skip this'))
             ])
             def test_model_b(self, a):
                 assert a == 1


### PR DESCRIPTION
This PR should allow for more complex combinations of lazy fixtures:
- On the one hand, if a test/fixture is parametrized with one or more `lazy_fixture`s that require other parametrized fixtures themselves, this would now result in an error (see test `test_lazy_fixtures_with_subfixtures`)
This should also fix issue #23, as demonstrated in the added test `test_issues23`.
- On the other hand, fixtures requiring subfixures with parametrized with `lazy_fixture`s would not have these lazy fixtures resolved (resulting in type errors; see test `test_lazy_fixtures_in_subfixture`).
This is similar to PR #28, except that it resolves nested `lazy_fixture`s in the parameters instead of as return values (as I am assuming is the aim of this project?).

EDIT:
Oh, yes, the first commit of this PR also fixes a few existing tests, after direct application of marks inside `parametrize` values were deprecated/removed.

