### PR TITLE
Use Metafunc.parametrize to reuse more code from pytest

### DIFF
--- a/pytest_lazyfixture.py
+++ b/pytest_lazyfixture.py
@@ -41,6 +41,13 @@ def fillfixtures(_fillfixtures):
     return fill
 
 
+@pytest.hookimpl(tryfirst=True)
+def pytest_fixture_setup(fixturedef, request):
+    val = getattr(request, 'param', None)
+    if is_lazy_fixture(val):
+        request.param = request.getfixturevalue(val.name)
+
+
 def pytest_runtest_call(item):
     if hasattr(item, 'funcargs'):
         for arg, val in item.funcargs.items():

--- a/tests/test_lazyfixture.py
+++ b/tests/test_lazyfixture.py
@@ -373,7 +373,7 @@ def test_issues10_xfail(testdir):
             return request.param
 
         @pytest.mark.parametrize(('a', 'b'), [
-            pytest.mark.xfail((1, pytest.lazy_fixture('zero')), reason=ZeroDivisionError)
+            pytest.param(1, pytest.lazy_fixture('zero'), marks=pytest.mark.xfail(reason=ZeroDivisionError))
         ])
         def test_division(a, b):
             division(a, b)
@@ -411,7 +411,7 @@ def test_issues12_skip_test_function(testdir):
             return 1
 
         @pytest.mark.parametrize('a', [
-            pytest.mark.skip(pytest.lazy_fixture('one'), reason='skip')
+            pytest.param(pytest.lazy_fixture('one'), marks=pytest.mark.skip(reason='skip'))
         ])
         def test_skip1(a):
             assert a == 1
@@ -447,7 +447,7 @@ def test_issues12_skip_test_method(testdir):
                 assert a == 1
 
             @pytest.mark.parametrize('a', [
-                pytest.mark.skip(pytest.lazy_fixture('one'), reason='skip this')
+                pytest.param(pytest.lazy_fixture('one'), marks=pytest.mark.skip(reason='skip this'))
             ])
             def test_model_b(self, a):
                 assert a == 1


### PR DESCRIPTION
By creating a new Metafunc, and calling its `parametrize` method, we can avoid some code and solve some outstanding TODOs, such as getting the fixture IDs of `lazy_fixtures` the same as for normal fixtures.

It builds further on PR #31, since part of the changes are shared/similar.