### PR TITLE
Adding pytest_make_parametrize_id implementation to get better default ids for lazy fixtures

### DIFF
--- a/pytest_lazyfixture.py
+++ b/pytest_lazyfixture.py
@@ -62,6 +62,11 @@ def pytest_pycollect_makeitem(collector, name, obj):
     current_node = None
 
 
+def pytest_make_parametrize_id(config, val, argname):
+    if is_lazy_fixture(val):
+        return val.name
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_generate_tests(metafunc):
     yield


### PR DESCRIPTION
See #46