### PR TITLE
prevent error from LazyFixture('lol') == 1

### DIFF
--- a/pytest_lazyfixture.py
+++ b/pytest_lazyfixture.py
@@ -194,4 +194,6 @@ class LazyFixture(object):
         return '<{} "{}">'.format(self.__class__.__name__, self.name)
 
     def __eq__(self, other):
-        return self.name == other.name
+        if isinstance(other, LazyFixture):
+            return self.name == other.name
+        return NotImplemented

--- a/tests/test_lazyfixture.py
+++ b/tests/test_lazyfixture.py
@@ -904,3 +904,9 @@ def test_lazy_fixture_ids(testdir):
     assert 'test_the_thing[foo]' in stdout
     assert 'test_the_thing[bar-spam]' in stdout
     assert 'test_the_thing[bar-eggs]' in stdout
+
+
+def test_eq():
+    assert lazy_fixture("Lol") == lazy_fixture("Lol")
+    assert lazy_fixture("Lol") != lazy_fixture("Wut")
+    assert lazy_fixture("Lol") != 123


### PR DESCRIPTION
It's recommended that `__eq__` handles any object. Even though `LazyFixture('lol') == 1` doesn't make much sense, something like `LazyFixture('lol') == None` should be `False`, not an error.