### PR TITLE
Readme: clarify simple usecase

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,26 @@ Installation
 Usage
 -----
 
+pytest-lazy-fixture lets you use a fixture as one of the values passed
+in ``@pytest.mark.parametrize``:
+
+.. code-block:: python
+
+    import pytest
+    from pytest_lazyfixture import lazy_fixture
+
+    @pytest.fixture
+    def one():
+        return 1
+
+    @pytest.mark.parametrize('arg1,arg2', [
+        ('val1', lazy_fixture('one')),
+    ])
+    def test_func(arg1, arg2):
+        assert arg2 == 1
+
+This can be even more useful when the fixture is itself parametrized.
+
 .. code-block:: python
 
     import pytest

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ in ``@pytest.mark.parametrize``:
     def test_func(arg1, arg2):
         assert arg2 == 1
 
-This can be even more useful when the fixture is itself parametrized.
+This can be even more useful when the fixture is itself parametrized:
 
 .. code-block:: python
 


### PR DESCRIPTION
In this PR, I change the first example in the readme.

For someone who doesn't already know what the lib does, it can be confusing that the first example of using a fixture in a parametrize call actually also uses a parametrized fixture, and one could quickly reach the conclusion that the lib is not actually here to solve their problem (putting fixtures in parametrize) but the other, close but different problem (putting parametrize in fixtures).